### PR TITLE
Update README example to use checkout@v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Git Repo Sync
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - uses: wangchucheng/git-repo-sync@v0.1.0


### PR DESCRIPTION
Update README example to checkout@v4 as the old checkout@v2 uses the deprecated node12